### PR TITLE
feature/API-23/generic-product-service

### DIFF
--- a/src/generic-product.ts
+++ b/src/generic-product.ts
@@ -1,0 +1,83 @@
+import type { Client } from './client'
+import type { ManufacturerResponse } from './manufacturer'
+import type { BaseModel, Pagination, PaginationRequest } from './utils/models'
+
+export type GenericProduct = {
+  name: string
+  genericName: string
+  priority: number
+  description?: string
+}
+
+export type CreateGenericProduct = GenericProduct & {
+  manufacturerId: string
+}
+
+export type UpdateGenericProduct = Partial<CreateGenericProduct>
+export type ResponseGenericProduct = GenericProduct &
+  BaseModel & {
+    manufacturer: ManufacturerResponse
+  }
+
+export class GenericProductService {
+  private client: Client
+
+  constructor(client: Client) {
+    this.client = client
+    this.getById = this.getById.bind(this)
+    this.findAll = this.findAll.bind(this)
+    this.create = this.create.bind(this)
+    this.update = this.update.bind(this)
+    this.delete = this.delete.bind(this)
+  }
+
+  async getById(id: string): Promise<ResponseGenericProduct> {
+    const response = await this.client.get({
+      url: `/product/generic/${id}`,
+    })
+    return response as unknown as ResponseGenericProduct
+  }
+
+  async findAll({
+    page = 1,
+    limit = 10,
+  }: PaginationRequest): Promise<Pagination<ResponseGenericProduct>> {
+    const response = await this.client.get({
+      url: '/product/generic',
+      params: { page, limit },
+    })
+    return response as Pagination<ResponseGenericProduct>
+  }
+
+  async create(
+    genericProduct: CreateGenericProduct,
+    jwt: string,
+  ): Promise<ResponseGenericProduct> {
+    const response = await this.client.post({
+      url: '/product/generic',
+      data: genericProduct,
+      jwt,
+    })
+    return response as unknown as ResponseGenericProduct
+  }
+
+  async update(
+    id: string,
+    partialGenericProduct: UpdateGenericProduct,
+    jwt: string,
+  ): Promise<ResponseGenericProduct> {
+    const response = await this.client.patch({
+      url: `/product/generic/${id}`,
+      data: partialGenericProduct,
+      jwt,
+    })
+    return response as unknown as ResponseGenericProduct
+  }
+
+  async delete(id: string, jwt: string): Promise<void> {
+    await this.client.delete({
+      url: `/product/generic/${id}`,
+      jwt,
+    })
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { BranchService } from './branch'
 import { CategoryService } from './category'
 import { Client } from './client'
 import { CountryService } from './country'
+import { GenericProductService } from './generic-product'
 import { ManufacturerService } from './manufacturer'
 import { PresentationService } from './presentation'
 import { ProductService } from './product'
@@ -21,6 +22,7 @@ export class PharmaTech {
   category: CategoryService
   presentation: PresentationService
   manufacturer: ManufacturerService
+  genericProduct: GenericProductService
 
   /**
    * @deprecated Use `PharmaTech.getInstance()` instead.
@@ -36,6 +38,7 @@ export class PharmaTech {
     this.category = new CategoryService(this.client)
     this.presentation = new PresentationService(this.client)
     this.manufacturer = new ManufacturerService(this.client)
+    this.genericProduct = new GenericProductService(this.client)
   }
 
   static getInstance(isDevMode = false): PharmaTech {


### PR DESCRIPTION
This pull request introduces a new `GenericProductService` to manage generic products in the system. The changes include defining new types and adding the service to the main `PharmaTech` class.

Key changes:

### Addition of `GenericProductService`:

* [`src/generic-product.ts`](diffhunk://#diff-535cc64f6213fe477906aab913a83d52a33e0373007bec89b334c55e5a5c6456R1-R83): Added the `GenericProductService` class with methods for CRUD operations and defined related types (`GenericProduct`, `CreateGenericProduct`, `UpdateGenericProduct`, `ResponseGenericProduct`).

### Integration into `PharmaTech`:

* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R6): Imported `GenericProductService` and added it to the `PharmaTech` class, ensuring it is instantiated along with other services. [[1]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R6) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R25) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R41)