### PR TITLE
feature/add-start-at-promo

### DIFF
--- a/src/types/promo.ts
+++ b/src/types/promo.ts
@@ -1,9 +1,9 @@
 import type { BaseModel } from './utils'
 
 export type Promo = {
-  productPresentationId: string
   name: string
   discount: number
+  startAt: Date
   expiredAt: Date
 }
 


### PR DESCRIPTION
This pull request includes changes to the `src/types/promo.ts` file to update the `Promo` type definition. The most important change is the addition of new fields to the `Promo` type and the removal of an existing field.

Changes to `Promo` type definition:

* [`src/types/promo.ts`](diffhunk://#diff-4e6c4f29d97e361af8b0cf27598f012ee4972cd2fccef141b29e5a58b1827f79L4-R6): Removed the `productPresentationId` field from the `Promo` type.
* [`src/types/promo.ts`](diffhunk://#diff-4e6c4f29d97e361af8b0cf27598f012ee4972cd2fccef141b29e5a58b1827f79L4-R6): Added `startAt` field to the `Promo` type to indicate the start date of the promotion.