### PR TITLE
Feature/api 47/add filter get products

### DIFF
--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -16,10 +16,25 @@ export class ProductService {
     page,
     limit,
     q,
+    manufacturerId,
+    categoryId,
+    branchId,
+    presentationId,
+    priceRange,
   }: ProductPaginationRequest): Promise<Pagination<ProductPresentation>> {
+    const params = {
+      page: page || 1,
+      limit: limit || 10,
+      q,
+      manufacturerId: manufacturerId?.join(','),
+      categoryId: categoryId?.join(','),
+      branchId: branchId?.join(','),
+      presentationId: presentationId?.join(','),
+      priceRange: [priceRange?.min, priceRange?.max].join(','),
+    }
     const response = await this.client.get({
       url: '/product',
-      params: { page, limit, q },
+      params,
     })
 
     return response as unknown as Pagination<ProductPresentation>

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -22,4 +22,9 @@ export type ProductPresentation = BaseModel & {
 
 export type ProductPaginationRequest = PaginationRequest & {
   q?: string
+  manufacturerId?: string[]
+  categoryId?: string[]
+  branchId?: string[]
+  presentationId?: string[]
+  priceRange?: { min: number; max: number }
 }


### PR DESCRIPTION
This pull request includes changes to the `ProductService` class and the `ProductPaginationRequest` type to support additional filtering options for product pagination requests. The most important changes are summarized below:

Enhancements to product pagination:

* [`src/services/product.ts`](diffhunk://#diff-fd2cfb4624ef03c94fb2a09c00a2b915e25e8c59c61381c994178e0773813b90R19-R37): Added new parameters `manufacturerId`, `categoryId`, `branchId`, `presentationId`, and `priceRange` to the `ProductPaginationRequest` and updated the `params` object to include these new filters.
* [`src/types/product.ts`](diffhunk://#diff-f78da5c06fcf4860d9202f9138e2a9916359a11b9ee947cf0a5d218ea310ed6fR25-R29): Updated the `ProductPaginationRequest` type to include optional fields for `manufacturerId`, `categoryId`, `branchId`, `presentationId`, and `priceRange`.