### PR TITLE
Release 0.4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pharmatech/sdk",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "PharmaTech Core API SDK",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,7 +94,7 @@ export class PharmaTech {
   }
 
   version(): string {
-    return '0.4.9'
+    return '0.4.10'
   }
 }
 

--- a/src/services/coupon.ts
+++ b/src/services/coupon.ts
@@ -1,9 +1,9 @@
 import type { Client } from '../client'
 import type {
   Pagination,
-  PaginationRequest,
   Coupon,
   CouponResponse,
+  CouponPaginationRequest,
 } from '../types'
 
 export class CouponService {
@@ -27,12 +27,20 @@ export class CouponService {
   }
 
   async findAll(
-    { page = 1, limit = 10, q }: PaginationRequest,
+    { page = 1, limit = 10, q, expirationBetween }: CouponPaginationRequest,
     jwt: string,
   ): Promise<Pagination<CouponResponse>> {
+    const params = {
+      page,
+      limit,
+      q,
+      expirationBetween: expirationBetween
+        ? [expirationBetween.start, expirationBetween.end].join(',')
+        : undefined,
+    }
     const response = await this.client.get({
       url: '/coupon',
-      params: { page, limit, q },
+      params,
       jwt,
     })
     return response as Pagination<CouponResponse>

--- a/src/services/coupon.ts
+++ b/src/services/coupon.ts
@@ -27,12 +27,12 @@ export class CouponService {
   }
 
   async findAll(
-    { page = 1, limit = 10 }: PaginationRequest,
+    { page = 1, limit = 10, q }: PaginationRequest,
     jwt: string,
   ): Promise<Pagination<CouponResponse>> {
     const response = await this.client.get({
       url: '/coupon',
-      params: { page, limit },
+      params: { page, limit, q },
       jwt,
     })
     return response as Pagination<CouponResponse>

--- a/src/services/presentation.ts
+++ b/src/services/presentation.ts
@@ -29,10 +29,11 @@ export class PresentationService {
   async findAll({
     page = 1,
     limit = 10,
+    q,
   }: PaginationRequest): Promise<Pagination<PresentationResponse>> {
     const response = await this.client.get({
       url: '/presentation',
-      params: { page, limit },
+      params: { page, limit, q },
     })
     return response as Pagination<PresentationResponse>
   }

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -10,6 +10,7 @@ export class ProductService {
   constructor(client: Client) {
     this.client = client
     this.getProducts = this.getProducts.bind(this)
+    this.getRecommendations = this.getRecommendations.bind(this)
   }
 
   async getProducts({
@@ -39,6 +40,17 @@ export class ProductService {
     const response = await this.client.get({
       url: '/product',
       params,
+    })
+
+    return response as unknown as Pagination<ProductPresentation>
+  }
+
+  async getRecommendations(
+    jwt: string,
+  ): Promise<Pagination<ProductPresentation>> {
+    const response = await this.client.get({
+      url: '/product/recommendations',
+      jwt,
     })
 
     return response as unknown as Pagination<ProductPresentation>

--- a/src/services/product.ts
+++ b/src/services/product.ts
@@ -23,6 +23,7 @@ export class ProductService {
     presentationId,
     genericProductId,
     priceRange,
+    isVisible,
   }: ProductPaginationRequest): Promise<Pagination<ProductPresentation>> {
     const params = {
       page: page || 1,
@@ -36,6 +37,7 @@ export class ProductService {
       priceRange: priceRange
         ? [priceRange?.min, priceRange?.max].join(',')
         : undefined,
+      isVisible,
     }
     const response = await this.client.get({
       url: '/product',

--- a/src/services/promo.ts
+++ b/src/services/promo.ts
@@ -1,8 +1,8 @@
 import type { Client } from '../client'
 import type {
   Pagination,
-  PaginationRequest,
   Promo,
+  PromoPaginationRequest,
   PromoResponse,
 } from '../types'
 
@@ -27,12 +27,20 @@ export class PromoService {
   }
 
   async findAll(
-    { page = 1, limit = 10, q }: PaginationRequest,
+    { page = 1, limit = 10, q, expirationBetween }: PromoPaginationRequest,
     jwt: string,
   ): Promise<Pagination<PromoResponse>> {
+    const params = {
+      page,
+      limit,
+      q,
+      expirationBetween: expirationBetween
+        ? [expirationBetween.start, expirationBetween.end].join(',')
+        : undefined,
+    }
     const response = await this.client.get({
       url: '/promo',
-      params: { page, limit, q },
+      params,
       jwt,
     })
     return response as Pagination<PromoResponse>

--- a/src/services/promo.ts
+++ b/src/services/promo.ts
@@ -27,12 +27,12 @@ export class PromoService {
   }
 
   async findAll(
-    { page = 1, limit = 10 }: PaginationRequest,
+    { page = 1, limit = 10, q }: PaginationRequest,
     jwt: string,
   ): Promise<Pagination<PromoResponse>> {
     const response = await this.client.get({
       url: '/promo',
-      params: { page, limit },
+      params: { page, limit, q },
       jwt,
     })
     return response as Pagination<PromoResponse>

--- a/src/types/coupon.ts
+++ b/src/types/coupon.ts
@@ -1,4 +1,4 @@
-import type { BaseModel } from './utils'
+import type { BaseModel, PaginationRequest } from './utils'
 
 export type Coupon = {
   code: string
@@ -9,3 +9,10 @@ export type Coupon = {
 }
 
 export type CouponResponse = Coupon & BaseModel
+
+export type CouponPaginationRequest = PaginationRequest & {
+  expirationBetween?: {
+    start: Date
+    end: Date
+  }
+}

--- a/src/types/delivery.ts
+++ b/src/types/delivery.ts
@@ -27,7 +27,6 @@ export type UserOrderDeliveryDetailResponse = {
 
 export type AddressOrderDeliveryDetailResponse = {
   adress: string
-  zipCode: string
   additionalInformation: string
   referencePoint: string
   latitude: number

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -29,4 +29,5 @@ export type ProductPaginationRequest = PaginationRequest & {
   presentationId?: string[]
   genericProductId?: string[]
   priceRange?: { min: number; max: number }
+  isVisible?: boolean
 }

--- a/src/types/product.ts
+++ b/src/types/product.ts
@@ -18,6 +18,7 @@ export type ProductPresentation = BaseModel & {
   price: number
   presentation: PresentationResponse
   product: Product
+  stock: number
 }
 
 export type ProductPaginationRequest = PaginationRequest & {

--- a/src/types/promo.ts
+++ b/src/types/promo.ts
@@ -1,4 +1,4 @@
-import type { BaseModel } from './utils'
+import type { BaseModel, PaginationRequest } from './utils'
 
 export type Promo = {
   name: string
@@ -8,3 +8,10 @@ export type Promo = {
 }
 
 export type PromoResponse = Promo & BaseModel
+
+export type PromoPaginationRequest = PaginationRequest & {
+  expirationBetween?: {
+    start: Date
+    end: Date
+  }
+}

--- a/src/types/user-address.ts
+++ b/src/types/user-address.ts
@@ -1,6 +1,5 @@
 export type UserAddressResponse = {
   adress: string
-  zipCode: string
   latitude: number | null
   longitude: number | null
   cityId: string
@@ -14,7 +13,6 @@ export type UserAddressResponse = {
 
 export type CreateUserAddressRequest = {
   adress: string
-  zipCode: string
   latitude: number | null
   longitude: number | null
   cityId: string


### PR DESCRIPTION
This pull request introduces several updates to the PharmaTech SDK, including version bumps, enhancements to service methods, and changes to type definitions. The most significant updates include the addition of new request parameters for `CouponService`, `PromoService`, and `ProductService`, the introduction of a new `getRecommendations` method in `ProductService`, and adjustments to type definitions to support these changes.

### Version Updates:
* Updated the SDK version from `0.4.9` to `0.4.10` in `package.json` and the `version()` method in `src/index.ts`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L97-R97)

### Service Enhancements:
* **CouponService**: Added `q` and `expirationBetween` parameters to the `findAll` method for more flexible coupon queries.
* **PromoService**: Added `q` and `expirationBetween` parameters to the `findAll` method for more flexible promo queries.
* **ProductService**: 
  - Added `isVisible` parameter to the `getProducts` method for filtering products by visibility. [[1]](diffhunk://#diff-fd2cfb4624ef03c94fb2a09c00a2b915e25e8c59c61381c994178e0773813b90R26) [[2]](diffhunk://#diff-fd2cfb4624ef03c94fb2a09c00a2b915e25e8c59c61381c994178e0773813b90R40)
  - Introduced a new `getRecommendations` method to fetch product recommendations.

### Type Definition Updates:
* **Coupon Types**: Introduced `CouponPaginationRequest` to support `expirationBetween` queries in `CouponService`.
* **Promo Types**: Introduced `PromoPaginationRequest` to support `expirationBetween` queries in `PromoService`.
* **Product Types**: Added `stock` to `ProductPresentation` and `isVisible` to `ProductPaginationRequest`. [[1]](diffhunk://#diff-f78da5c06fcf4860d9202f9138e2a9916359a11b9ee947cf0a5d218ea310ed6fR21) [[2]](diffhunk://#diff-f78da5c06fcf4860d9202f9138e2a9916359a11b9ee947cf0a5d218ea310ed6fR32)

### Minor Changes:
* Removed `zipCode` from `UserAddressResponse` and `AddressOrderDeliveryDetailResponse` type definitions. [[1]](diffhunk://#diff-9f808bce50e73e6a27556daa84c1faec431bbb5e3c5b129261594b0b9c16886dL30) [[2]](diffhunk://#diff-a7a6ac28132343ff8b8bf1d6b4f6aab743ccafafaae01fd6b988f408b3a4d59eL3) [[3]](diffhunk://#diff-a7a6ac28132343ff8b8bf1d6b4f6aab743ccafafaae01fd6b988f408b3a4d59eL17)
* Added optional `q` parameter to `PresentationService`'s `findAll` method for query-based searches.